### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(name='iptoolsjj',
       url='https://github.com/jarekj9/iptoolsjj',
       author='Jaroslaw Jankun',
       author_email='jaroslaw.jankun@gmail.com',
-      license='MIT',
       packages=['iptoolsjj'],
+      classifiers=[
+          'License :: OSI Approved :: MIT License'
+      ]
       zip_safe=False)


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.